### PR TITLE
Temporary full, and target ideal seat map files added

### DIFF
--- a/payload/dal3class.json
+++ b/payload/dal3class.json
@@ -1,0 +1,1463 @@
+{
+    "specs": {
+        "prefix": "A32NX",
+        "emptyPosition": -8.75,
+        "macSize": 13.754,
+        "leMacZ": -5.786,
+        "weights": {
+            "maxZfw": 64300,
+            "minZfw": 42500
+        },
+        "pax": {
+            "defaultPaxWeight": 80,
+            "defaultBagWeight": 15,
+            "minPaxWeight": 10,
+            "maxPaxWeight": 250,
+            "minBagWeight": 1,
+            "maxBagWeight": 250
+        }
+    },
+    "seatMap": [
+        {
+            "name": "ROWS [1-6]",
+            "rows": [
+                {
+                    "seats": [
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 5
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 29
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 5
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0.25,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 5
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 29
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 5
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0.25,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 5
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 29
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 5
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0.25,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 5
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 29
+                        },
+                        {
+                            "type": 3,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 5
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0.25,
+                    "yOffset": 0
+                }
+            ],
+            "index": 0,
+            "stationIndex": 4,
+            "position": 21.98,
+            "fill": 0.11,
+            "simVar": "A32NX_PAX_TOTAL_ROWS_1_6"
+        },
+        {
+            "name": "ROWS [7-13]",
+            "rows": [
+                {
+                    "seats": [
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0.12,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0.12,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 2,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0.12,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                }
+            ],
+            "index": 1,
+            "stationIndex": 3,
+            "position": 2.86,
+            "fill": 0.27,
+            "simVar": "A32NX_PAX_TOTAL_ROWS_7_13"
+        },
+        {
+            "name": "ROWS [14-21]",
+            "rows": [
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 6,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 6,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                }
+            ],
+            "index": 2,
+            "stationIndex": 1,
+            "position": -15.34,
+            "fill": 0.31,
+            "simVar": "A32NX_PAX_TOTAL_ROWS_14_21"
+        },
+        {
+            "name": "ROWS [22-29]",
+            "rows": [
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 19
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                },
+                {
+                    "seats": [
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        },
+                        {
+                            "type": 0,
+                            "x": 0,
+                            "y": 0,
+                            "yOffset": 0
+                        }
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "xOffset": 0,
+                    "yOffset": 0
+                }
+            ],
+            "fill": 0.33,
+            "index": 3,
+            "stationIndex": 2,
+            "position": -32.81,
+            "simVar": "A32NX_PAX_TOTAL_ROWS_22_29"
+        }
+    ],
+    "cargoMap": [
+        {
+            "name": "FWD BAGGAGE/CONTAINER",
+            "weight": 3402,
+            "index": 0,
+            "stationIndex": 5,
+            "position": 18.28,
+            "progressBarWidth": 160,
+            "simVar": "A32NX_CARGO_FWD_BAGGAGE_CONTAINER"
+        },
+        {
+            "name": "AFT CONTAINER",
+            "weight": 2426,
+            "index": 1,
+            "stationIndex": 6,
+            "position": -15.96,
+            "progressBarWidth": 100,
+            "simVar": "A32NX_CARGO_AFT_CONTAINER"
+        },
+        {
+            "name": "AFT BAGGAGE",
+            "weight": 2110,
+            "index": 2,
+            "stationIndex": 7,
+            "position": -27.1,
+            "progressBarWidth": 100,
+            "simVar": "A32NX_CARGO_AFT_BAGGAGE"
+        },
+        {
+            "name": "AFT BULK/LOOSE",
+            "weight": 1497,
+            "index": 3,
+            "stationIndex": 8,
+            "position": -37.35,
+            "progressBarWidth": 100,
+            "simVar": "A32NX_CARGO_AFT_BULK_LOOSE"
+        }
+    ],
+    "chart": {
+        "performanceEnvelope": {
+            "mlw": [
+                [
+                    15,
+                    42500
+                ],
+                [
+                    15,
+                    53000
+                ],
+                [
+                    17,
+                    63000
+                ],
+                [
+                    17,
+                    67400
+                ],
+                [
+                    40,
+                    67400
+                ],
+                [
+                    40,
+                    50000
+                ],
+                [
+                    35,
+                    46000
+                ],
+                [
+                    35,
+                    42500
+                ]
+            ],
+            "mzfw": [
+                [
+                    17,
+                    64300
+                ],
+                [
+                    40,
+                    64300
+                ],
+                [
+                    40,
+                    50000
+                ],
+                [
+                    35,
+                    46000
+                ],
+                [
+                    35,
+                    42500
+                ],
+                [
+                    15,
+                    42500
+                ]
+            ],
+            "mtow": [
+                [
+                    15,
+                    42500
+                ],
+                [
+                    15,
+                    53000
+                ],
+                [
+                    17,
+                    63000
+                ],
+                [
+                    17,
+                    72000
+                ],
+                [
+                    27,
+                    79000
+                ],
+                [
+                    36,
+                    79000
+                ],
+                [
+                    40,
+                    73500
+                ],
+                [
+                    40,
+                    58000
+                ],
+                [
+                    33,
+                    42500
+                ]
+            ],
+            "flight": [
+                [
+                    13,
+                    42500
+                ],
+                [
+                    13,
+                    52500
+                ],
+                [
+                    15,
+                    63000
+                ],
+                [
+                    15,
+                    72000
+                ],
+                [
+                    25,
+                    79000
+                ],
+                [
+                    38,
+                    79000
+                ],
+                [
+                    41,
+                    74500
+                ],
+                [
+                    41,
+                    51000
+                ],
+                [
+                    35,
+                    46000
+                ],
+                [
+                    35,
+                    42500
+                ],
+                [
+                    13,
+                    42500
+                ]
+            ]
+        },
+        "chartLimits": {
+            "weight": {
+                "min": 40000,
+                "max": 80000,
+                "lines": 9,
+                "scale": 5000,
+                "values": [
+                    80,
+                    70,
+                    60,
+                    50,
+                    40
+                ]
+            },
+            "cg": {
+                "angleRad": 0.014025,
+                "min": 12,
+                "max": 47,
+                "overlap": 32,
+                "highlight": 5,
+                "lines": 35,
+                "scale": 1,
+                "values": [
+                    15,
+                    20,
+                    25,
+                    30,
+                    35,
+                    40
+                ]
+            },
+            "labels": {
+                "mtow": {
+                    "x1": 0.65,
+                    "x2": 0.22,
+                    "y": 0.02
+                },
+                "mlw": {
+                    "x1": 0.65,
+                    "x2": 0.22,
+                    "y": 0.22
+                },
+                "mzfw": {
+                    "x1": 0.65,
+                    "x2": 0.22,
+                    "y": 0.29
+                }
+            }
+        }
+    }
+}

--- a/payload/payload.json
+++ b/payload/payload.json
@@ -1,0 +1,120 @@
+{
+    "specs": {
+        "payload-type": 1,
+        "payload-name": "DAL 3-class",
+        "prefix": "A32NX",
+        "emptyPosition": -8.75,
+        "macSize": 13.454,
+        "leMacZ": -5.386,
+        "weights": {
+            "maxZfw": 64300,
+            "minZfw": 42500
+        },
+        "pax": {
+            "defaultPaxWeight": 80,
+            "defaultBagWeight": 15,
+            "minPaxWeight": 10,
+            "maxPaxWeight": 250,
+            "minBagWeight": 1,
+            "maxBagWeight": 250
+        },
+        "class-weight-modifier": {
+            "FIRSTCLASS": 95,
+            "COMFORTPLUS": 8,
+            "PREFERRED": 0,
+            "ECO": 0
+        }
+    },
+    "colors": {
+        "1": "4F0147",
+        "2": "119DA4",
+        "3": "19647E"
+    },
+    "payload-seatmap": {
+        "section-1": {
+            "name": "FIRSTCLASS",
+            "rows": 4,
+            "cols": 4,
+            "seat-img": {
+                "len": 19.2,
+                "wid": 24.4,
+                "padX": 28,
+                "padY": 0,
+                "imageX": 25.4,
+                "imageY": 24.4,
+                "color": 3
+            }
+        },
+        "section-2": {
+            "name": "COMFORTPLUS",
+            "rows": 6,
+            "cols": 3,
+            "seat-img": {
+                "len": 19.2,
+                "wid": 19.2,
+                "padX": 16,
+                "padY": 0,
+                "imageX": 25.4,
+                "imageY": 19.2,
+                "color": 2
+            }
+        },
+        "section-3": {
+            "name": "PREFERRED",
+            "rows": 6,
+            "cols": 2,
+            "seat-img": {
+                "len": 19.2,
+                "wid": 19.2,
+                "padX": 20,
+                "padY": 0,
+                "imageX": 19.2,
+                "imageY": 19.2,
+                "color": 1
+            }
+        },
+        "section-4": {
+            "name": "ECO",
+            "rows": 6,
+            "cols": 7,
+            "seat-img": {
+                "len": 19.2,
+                "wid": 19.2,
+                "padX": 13,
+                "padY": 0,
+                "imageX": 19.2,
+                "imageY": 19.2,
+                "color": 1
+            }
+        },
+        "section-5": {
+            "name": "ECO",
+            "rows": 6,
+            "cols": 10,
+            "seat-img": {
+                "len": 19.2,
+                "wid": 19.2,
+                "padX": 13,
+                "padY": 0,
+                "imageX": 19.2,
+                "imageY": 19.2,
+                "color": 1
+            }
+        },
+        "section-6": {
+            "name": "ECO",
+            "aisle-side": "RIGHT",
+            "rows": 3,
+            "cols": 1,
+            "seat-img": {
+                "len": 19.2,
+                "wid": 19.2,
+                "padX": 13,
+                "padY": 0,
+                "imageX": 19.2,
+                "imageY": 19.2,
+                "color": 1
+            }
+        }
+    }
+}


### PR DESCRIPTION
the ideal seat map file is the eventual goal to dynamically load and generate seatmaps based on a simpler input

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
